### PR TITLE
Fix active model serializers dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'active_model_serializers_matchers', '0.2.0'
+gem 'active_model_serializers_matchers', '0.2.1'
 ```
 
 And then execute:

--- a/active_model_serializers_matchers.gemspec
+++ b/active_model_serializers_matchers.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency "active_model_serializers", "0.8.0"
+  spec.add_dependency "active_model_serializers", "~> 0.8.0"
   spec.add_dependency "rspec", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"

--- a/lib/active_model_serializers_matchers/version.rb
+++ b/lib/active_model_serializers_matchers/version.rb
@@ -1,3 +1,3 @@
 module ActiveModelSerializersMatchers
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
previously required `active_model_serializers, '0.8.0'` when `'~> 0.8.0'` was intended