### PR TITLE
Type and subject defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ class ListSerializer < ActiveModel::Serializer
 end
 
 RSpec.describe ListSerializer, :type => :serializer do
-  subject { described_class }
   it { should have_one(:title) }
   it { should have_many(:items) }
   it { should have_many(:cats) }
@@ -71,7 +70,6 @@ class ShoeRackSerializer < ActiveModel::Serializer
 end
 
 RSpec.describe ShoeRackSerializer, :type => :serializer do
-  subject { described_class }
   it { should have_many(:shoes).as(:kicks) }
   it { should have_many(:shoes).as(:ones_and_twos) }
 end
@@ -94,7 +92,6 @@ class ShoppingCartSerializer < ActiveModel::Serializer
 end
 
 RSpec.describe ShoppingCartSerializer, :type => :serializer do
-  subject { described_class }
   it { should have_many(:items).serialized_with(ProductSerializer) }
   it { should have_many(:items).serialized_with(SoupCanSerializer) }
 end
@@ -116,7 +113,6 @@ class MenuSerializer < ActiveModel::Serializer
 end
 
 RSpec.describe MenuSerializer, :type => :serializer do
-  subject { described_class }
   it { should have_many(:entrees).as(:dishes).serialized_with(FoodSerializer) }
   it { should have_many(:entrees).serialized_with(FoodSerializer).as(:dishes) }
 end

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Or install it yourself as:
 ### Configure RSpec
 ``` ruby
 RSpec.configure do |config|
-  config.include ActiveModelSerializersMatchers, :type => :serializer
+  config.include ActiveModelSerializersMatchers, file_path: /spec\/serializers/
 end
 ```
 
@@ -48,7 +48,7 @@ class ListSerializer < ActiveModel::Serializer
   has_many :items
 end
 
-RSpec.describe ListSerializer, :type => :serializer do
+RSpec.describe ListSerializer do
   it { should have_one(:title) }
   it { should have_many(:items) }
   it { should have_many(:cats) }
@@ -69,7 +69,7 @@ class ShoeRackSerializer < ActiveModel::Serializer
   has_many :shoes, key: :kicks
 end
 
-RSpec.describe ShoeRackSerializer, :type => :serializer do
+RSpec.describe ShoeRackSerializer do
   it { should have_many(:shoes).as(:kicks) }
   it { should have_many(:shoes).as(:ones_and_twos) }
 end
@@ -91,7 +91,7 @@ class ShoppingCartSerializer < ActiveModel::Serializer
   has_many :items, serializer: ProductSerializer
 end
 
-RSpec.describe ShoppingCartSerializer, :type => :serializer do
+RSpec.describe ShoppingCartSerializer, do
   it { should have_many(:items).serialized_with(ProductSerializer) }
   it { should have_many(:items).serialized_with(SoupCanSerializer) }
 end
@@ -112,7 +112,7 @@ class MenuSerializer < ActiveModel::Serializer
   has_many :entrees, key: :dishes, serializer: FoodSerializer
 end
 
-RSpec.describe MenuSerializer, :type => :serializer do
+RSpec.describe MenuSerializer do
   it { should have_many(:entrees).as(:dishes).serialized_with(FoodSerializer) }
   it { should have_many(:entrees).serialized_with(FoodSerializer).as(:dishes) }
 end

--- a/lib/active_model_serializers_matchers.rb
+++ b/lib/active_model_serializers_matchers.rb
@@ -1,6 +1,10 @@
 Dir[Pathname(__FILE__).join('../**/*.rb')].each { |f| require f }
 
 module ActiveModelSerializersMatchers
+  def self.included(base)
+    base.subject { described_class }
+  end
+
   def have_many(association_root)
     AssociationMatcher.new(association_root, :has_many)
   end

--- a/lib/active_model_serializers_matchers.rb
+++ b/lib/active_model_serializers_matchers.rb
@@ -3,6 +3,7 @@ Dir[Pathname(__FILE__).join('../**/*.rb')].each { |f| require f }
 module ActiveModelSerializersMatchers
   def self.included(base)
     base.subject { described_class }
+    metadata[:type] = :serializer
   end
 
   def have_many(association_root)

--- a/lib/active_model_serializers_matchers.rb
+++ b/lib/active_model_serializers_matchers.rb
@@ -3,7 +3,6 @@ Dir[Pathname(__FILE__).join('../**/*.rb')].each { |f| require f }
 module ActiveModelSerializersMatchers
   def self.included(base)
     base.subject { described_class }
-    metadata[:type] = :serializer
   end
 
   def have_many(association_root)


### PR DESCRIPTION
I found it quite annoying to have to specify `subject` over and over again. When you include `ActiveModelSerializersMatchers` we should execute the subject. There was also no need to specify the type. Instead of saying `type: :serializer` I switched it to `file_path: \spec/\serializers\`.

Hope this helps improve this gem. Its really quite good! :+1:
