### PR TITLE
AMS 0.10.0rc Ready

### DIFF
--- a/active_model_serializers_matchers.gemspec
+++ b/active_model_serializers_matchers.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency "active_model_serializers", "~> 0.8.0"
+  spec.add_dependency "active_model_serializers", "~> 0.10.0rc"
   spec.add_dependency "rspec", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"

--- a/lib/active_model_serializers_matchers.rb
+++ b/lib/active_model_serializers_matchers.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 Dir[Pathname(__FILE__).join('../**/*.rb')].each { |f| require f }
 
 module ActiveModelSerializersMatchers

--- a/lib/active_model_serializers_matchers/association_matcher/association_check.rb
+++ b/lib/active_model_serializers_matchers/association_matcher/association_check.rb
@@ -10,7 +10,7 @@ module ActiveModelSerializersMatchers
 
       def pass?
         return false if matcher.root_association.nil?
-        matcher.root_association.superclass == association_type
+        matcher.root_association[:type] == type
       end
 
       def fail?
@@ -26,17 +26,6 @@ module ActiveModelSerializersMatchers
       end
 
       private
-
-      def association_type
-        case type
-        when :has_one
-          ActiveModel::Serializer::Associations::HasOne
-        when :has_many
-          ActiveModel::Serializer::Associations::HasMany
-        else
-          raise ArgumentError, "'#{type}' is an invalid association type."
-        end
-      end
 
       def association_string
         case type

--- a/lib/active_model_serializers_matchers/association_matcher/embed_key_check.rb
+++ b/lib/active_model_serializers_matchers/association_matcher/embed_key_check.rb
@@ -27,7 +27,7 @@ module ActiveModelSerializersMatchers
       private
 
       def actual_embed_key
-        matcher.root_association.options[:embed_key]
+        matcher.root_association[:association_options][:embed_key]
       end
 
       def actual_embed_key_string

--- a/lib/active_model_serializers_matchers/association_matcher/key_check.rb
+++ b/lib/active_model_serializers_matchers/association_matcher/key_check.rb
@@ -27,7 +27,7 @@ module ActiveModelSerializersMatchers
       private
 
       def actual_key
-        matcher.root_association.options[:key]
+        matcher.root_association[:association_options][:key]
       end
 
       def actual_key_string

--- a/lib/active_model_serializers_matchers/association_matcher/serializer_check.rb
+++ b/lib/active_model_serializers_matchers/association_matcher/serializer_check.rb
@@ -27,7 +27,7 @@ module ActiveModelSerializersMatchers
       private
 
       def actual_serializer
-        matcher.root_association.options[:serializer]
+        matcher.root_association[:association_options][:serializer]
       end
 
       def actual_serializer_string

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ Coveralls.wear!
 require 'active_model_serializers'
 require 'active_model_serializers_matchers'
 
+require 'pathname'
 Dir[Pathname(__FILE__).join('../support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|


### PR DESCRIPTION
Matchers will now require to AMS `~> .0.10.0`
